### PR TITLE
Simplify `run_simple_tune_job` to use stable APIs

### DIFF
--- a/run_simple_tune_job.py
+++ b/run_simple_tune_job.py
@@ -1,34 +1,26 @@
 # From https://docs.ray.io/en/latest/tune/index.html
 
 import ray
-from ray import train, tune
 
-
-def objective(step, alpha, beta):
-    return (0.1 + alpha * step / 100) ** (-1) + beta * 0.1
-
-
-def training_function(config):
-    # Hyperparameters
-    alpha, beta = config["alpha"], config["beta"]
-    for step in range(10):
-        # Iterative training function - can be any arbitrary training procedure.
-        intermediate_score = objective(step, alpha, beta)
-        # Feed the score back back to Tune.
-        train.report(dict(mean_loss=intermediate_score))
+from ray import tune
 
 ray.init(address="auto")
+
+
+def objective(config):
+    score = config["a"] ** 2 + config["b"]
+    return {"score": score}
+
+
+search_space = {
+    "a": tune.grid_search([0.001, 0.01, 0.1, 1.0]),
+    "b": tune.choice([1, 2, 3]),
+}
+
+tuner = tune.Tuner(objective, param_space=search_space)
+
 print("Starting Ray Tune job")
-analysis = tune.run(
-    training_function,
-    config={
-        "alpha": tune.grid_search([0.001, 0.01, 0.1]),
-        "beta": tune.choice([1, 2, 3]),
-    },
-)
+results = tuner.fit()
 
-print("Best config: ", analysis.get_best_config(metric="mean_loss", mode="min"))
-
-# Get a dataframe for analyzing trial results.
-df = analysis.results_df
-print(df)
+print("Best config: ")
+print(results.get_best_result(metric="score", mode="min").config)


### PR DESCRIPTION
Previously `run_simple_tune_job.py` used an API that had a breaking change. This caused an issue because two different Ray branches, one before the change and one after the change, were both using this file as a sample tune script in their CI.  So before the change, one would fail, and after the change, the other would fail.

This PR updates the script to use a more stable API (from the front page of the docs.). I've tested it on Ray 2.6, 2.7 and master.

I don't remember the original reason why we had to use a CUJ in the Ray CI test, but on the Ray side we check for logs such as "Starting Tune job" and "best config", so I'm choosing to keep using Ray tune instead of simplifying the script even further (like just a single Ray Task).

To prevent this issue in the future, the Ray test should ideally upload the script to a remote github repo from its own branch at runtime. That way we prevent this cross-repo dependency. I think the main work would be to set up permissions to allow Ray to commit to a remote github repo.

Closes https://github.com/anyscale/runtime/issues/150